### PR TITLE
Add buddy input to onboarding

### DIFF
--- a/kesher/src/assets/locales/en.json
+++ b/kesher/src/assets/locales/en.json
@@ -18,6 +18,8 @@
     "healthPermissionDesc": "Kesher needs access to your health data to help maintain your personal resilience",
     "buddySelection": "Buddy Selection",
     "buddySelectionDesc": "Choose a friend who will be there when needed",
+    "buddyInputPlaceholder": "Friend name or phone",
+    "addBuddy": "Add Buddy",
     "notificationPermission": "Notification Permissions",
     "notificationPermissionDesc": "Allow us to notify you when a friend needs support",
     "getStarted": "Let's Get Started"

--- a/kesher/src/assets/locales/he.json
+++ b/kesher/src/assets/locales/he.json
@@ -18,6 +18,8 @@
     "healthPermissionDesc": "קשר צריכה גישה לנתוני הבריאות שלך כדי לסייע בשמירה על החוסן האישי",
     "buddySelection": "בחירת באדי",
     "buddySelectionDesc": "בחר חבר שיהיה איתך כשצריך",
+    "buddyInputPlaceholder": "שם או מספר טלפון של חבר",
+    "addBuddy": "הוסף חבר",
     "notificationPermission": "הרשאות התראות",
     "notificationPermissionDesc": "אפשר לנו לעדכן אותך כשחבר צריך תמיכה",
     "getStarted": "יאללה, בוא נתחיל"

--- a/kesher/src/screens/OnboardingScreen.tsx
+++ b/kesher/src/screens/OnboardingScreen.tsx
@@ -1,22 +1,25 @@
 import React, { useState } from 'react';
-import { 
-  View, 
-  Text, 
-  StyleSheet, 
-  SafeAreaView
+import {
+  View,
+  Text,
+  StyleSheet,
+  SafeAreaView,
+  TextInput,
 } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useDispatch } from 'react-redux';
 import { StackNavigationProp } from '@react-navigation/stack';
 
 import Button from '../components/Button';
-import { colors, typography, spacing } from '../utils/theme';
+import { colors, typography, spacing, borders } from '../utils/theme';
 import { t } from '../utils/i18n';
 import { setOnboarded } from '../services/slices/userSlice';
 import { setHealthPermission } from '../services/slices/healthSlice';
+import { addBuddy, Buddy } from '../services/slices/buddySlice';
 
 const OnboardingScreen = () => {
   const [step, setStep] = useState(0);
+  const [buddyValue, setBuddyValue] = useState('');
   const dispatch = useDispatch();
   const navigation = useNavigation<StackNavigationProp<any>>();
 
@@ -57,6 +60,23 @@ const OnboardingScreen = () => {
     }
   };
 
+  const handleAddBuddy = () => {
+    const value = buddyValue.trim();
+    if (!value) return;
+
+    const newBuddy: Buddy = {
+      id: value,
+      name: value,
+      phoneNumber: value,
+      status: 'offline',
+      lastActive: new Date().toISOString(),
+      isPrimary: false,
+    };
+
+    dispatch(addBuddy(newBuddy));
+    setBuddyValue('');
+  };
+
   const currentStep = steps[step];
 
   return (
@@ -78,6 +98,24 @@ const OnboardingScreen = () => {
         <View style={styles.textContainer}>
           <Text style={styles.title}>{currentStep.title}</Text>
           <Text style={styles.description}>{currentStep.description}</Text>
+
+          {step === 2 && (
+            <>
+              <TextInput
+                style={styles.input}
+                value={buddyValue}
+                onChangeText={setBuddyValue}
+                placeholder={t('onboarding.buddyInputPlaceholder')}
+              />
+
+              <Button
+                title={t('onboarding.addBuddy')}
+                onPress={handleAddBuddy}
+                fullWidth
+                style={styles.addBuddyButton}
+              />
+            </>
+          )}
         </View>
 
         <View style={styles.buttonContainer}>
@@ -146,6 +184,21 @@ const styles = StyleSheet.create({
     color: colors.grayText,
     textAlign: 'center',
     lineHeight: typography.lineHeight.md,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: colors.lightBorder,
+    borderRadius: borders.radius.md,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    width: '100%',
+    marginTop: spacing.md,
+    marginBottom: spacing.sm,
+    fontFamily: typography.fontFamily.regular,
+    fontSize: typography.fontSize.md,
+  },
+  addBuddyButton: {
+    marginTop: spacing.sm,
   },
   buttonContainer: {
     marginTop: spacing.xxl,


### PR DESCRIPTION
## Summary
- add a small form to the Buddy Selection onboarding step
- wire `addBuddy` action to the form
- provide translations for new buddy-related strings

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config file)*