### PR TITLE
Add BuddyChat screen & navigation

### DIFF
--- a/kesher/src/navigation/AppNavigator.tsx
+++ b/kesher/src/navigation/AppNavigator.tsx
@@ -15,6 +15,7 @@ import MoralInjuryScreen from '../screens/MoralInjuryScreen';
 import ReflexAIScreen from '../screens/ReflexAIScreen';
 import ProfileScreen from '../screens/ProfileScreen';
 import NotificationsScreen from '../screens/NotificationsScreen';
+import BuddyChatScreen from '../screens/BuddyChatScreen';
 
 // Theme colors
 import { colors } from '../utils/theme';
@@ -24,6 +25,7 @@ type RootStackParamList = {
   Onboarding: undefined;
   Main: undefined;
   Notifications: undefined;
+  BuddyChat: undefined;
 };
 
 type MainTabParamList = {
@@ -134,9 +136,17 @@ const AppNavigator = () => {
     >
       <Stack.Screen name="Onboarding" component={OnboardingScreen} />
       <Stack.Screen name="Main" component={MainTabNavigator} />
-      <Stack.Screen 
-        name="Notifications" 
-        component={NotificationsScreen} 
+      <Stack.Screen
+        name="BuddyChat"
+        component={BuddyChatScreen}
+        options={{
+          headerShown: true,
+          title: '',
+        }}
+      />
+      <Stack.Screen
+        name="Notifications"
+        component={NotificationsScreen}
         options={{
           headerShown: true,
           title: t('notifications.center'),

--- a/kesher/src/screens/BuddyChatScreen.tsx
+++ b/kesher/src/screens/BuddyChatScreen.tsx
@@ -1,0 +1,239 @@
+import React, { useState, useRef, useLayoutEffect } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TextInput,
+  FlatList,
+  TouchableOpacity,
+  KeyboardAvoidingView,
+  Platform,
+  useColorScheme,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useDispatch, useSelector } from 'react-redux';
+import { useNavigation } from '@react-navigation/native';
+
+import { colors, typography, spacing, borders, shadows } from '../utils/theme';
+import { t } from '../utils/i18n';
+import Button from '../components/Button';
+import { RootState } from '../services/store';
+import { addMessage, BuddyMessage } from '../services/slices/buddySlice';
+
+const BuddyChatScreen = () => {
+  const dispatch = useDispatch();
+  const navigation = useNavigation();
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === 'dark';
+
+  const { selectedBuddyId, buddies, messages } = useSelector(
+    (state: RootState) => state.buddy
+  );
+
+  const buddy = buddies.find((b) => b.id === selectedBuddyId);
+  const buddyMessages = messages.filter((m) => m.buddyId === selectedBuddyId);
+
+  const [inputText, setInputText] = useState('');
+  const flatListRef = useRef<FlatList>(null);
+
+  useLayoutEffect(() => {
+    if (buddy) {
+      navigation.setOptions({ title: buddy.name });
+    }
+  }, [navigation, buddy]);
+
+  const handleSend = () => {
+    if (!inputText.trim() || !selectedBuddyId) return;
+
+    const newMessage: Omit<BuddyMessage, 'timestamp' | 'isRead'> = {
+      id: Date.now().toString(),
+      buddyId: selectedBuddyId,
+      senderId: 'me',
+      text: inputText.trim(),
+    };
+
+    dispatch(addMessage(newMessage));
+    setInputText('');
+  };
+
+  const formatTime = (timestamp: number) => {
+    const date = new Date(timestamp);
+    return `${date.getHours()}:${date.getMinutes().toString().padStart(2, '0')}`;
+  };
+
+  const renderMessageItem = ({ item }: { item: BuddyMessage }) => (
+    <View
+      style={[
+        styles.messageBubble,
+        item.senderId === 'me' ? styles.userBubble : styles.aiBubble,
+        {
+          backgroundColor: item.senderId === 'me'
+            ? colors.accent
+            : isDark
+            ? colors.primaryDark
+            : colors.primaryLight,
+        },
+      ]}
+    >
+      <Text style={styles.messageText}>{item.text}</Text>
+      <Text style={styles.timeText}>{formatTime(item.timestamp)}</Text>
+    </View>
+  );
+
+  return (
+    <SafeAreaView
+      style={[
+        styles.container,
+        { backgroundColor: isDark ? colors.darkBackground : colors.lightBackground },
+      ]}
+    >
+      <KeyboardAvoidingView
+        style={styles.container}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        keyboardVerticalOffset={90}
+      >
+        <FlatList
+          ref={flatListRef}
+          data={buddyMessages}
+          renderItem={renderMessageItem}
+          keyExtractor={(item) => item.id}
+          contentContainerStyle={styles.messageList}
+          onContentSizeChange={() => flatListRef.current?.scrollToEnd({ animated: true })}
+          onLayout={() => flatListRef.current?.scrollToEnd({ animated: true })}
+        />
+
+        <View
+          style={[
+            styles.inputContainer,
+            {
+              backgroundColor: isDark ? colors.darkBackground : colors.lightBackground,
+              borderTopColor: isDark ? colors.darkBorder : colors.lightBorder,
+            },
+          ]}
+        >
+          <TextInput
+            style={[
+              styles.input,
+              {
+                backgroundColor: isDark ? '#1E1E1E' : '#F5F5F5',
+                color: isDark ? colors.lightText : colors.darkText,
+              },
+            ]}
+            value={inputText}
+            onChangeText={setInputText}
+            placeholder={t('chat.placeholder')}
+            placeholderTextColor={isDark ? colors.grayLight : colors.grayDark}
+            multiline
+          />
+
+          <TouchableOpacity
+            style={[
+              styles.sendButton,
+              {
+                backgroundColor: inputText.trim()
+                  ? colors.accent
+                  : isDark
+                  ? colors.darkBorder
+                  : colors.lightBorder,
+              },
+            ]}
+            onPress={handleSend}
+            disabled={!inputText.trim()}
+          >
+            <Ionicons
+              name="send"
+              size={24}
+              color={inputText.trim() ? colors.lightText : colors.grayDark}
+            />
+          </TouchableOpacity>
+        </View>
+
+        <View style={styles.sosContainer}>
+          <Button
+            title={t('chat.sos')}
+            onPress={() => {
+              const sosMessage: Omit<BuddyMessage, 'timestamp' | 'isRead'> = {
+                id: Date.now().toString(),
+                buddyId: selectedBuddyId || 'unknown',
+                senderId: 'system',
+                text: t('chat.supportReady'),
+              };
+              dispatch(addMessage(sosMessage));
+            }}
+            variant="danger"
+            size="small"
+          />
+        </View>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  messageList: {
+    padding: spacing.md,
+    paddingBottom: 80,
+  },
+  messageBubble: {
+    maxWidth: '80%',
+    padding: spacing.md,
+    borderRadius: borders.radius.lg,
+    marginBottom: spacing.md,
+    ...shadows.light,
+  },
+  userBubble: {
+    alignSelf: 'flex-end',
+    borderBottomRightRadius: borders.radius.sm,
+  },
+  aiBubble: {
+    alignSelf: 'flex-start',
+    borderBottomLeftRadius: borders.radius.sm,
+  },
+  messageText: {
+    fontFamily: typography.fontFamily.regular,
+    fontSize: typography.fontSize.md,
+    color: colors.lightText,
+  },
+  timeText: {
+    fontFamily: typography.fontFamily.regular,
+    fontSize: typography.fontSize.xs,
+    color: 'rgba(255, 255, 255, 0.7)',
+    alignSelf: 'flex-end',
+    marginTop: spacing.xs,
+  },
+  inputContainer: {
+    flexDirection: 'row',
+    padding: spacing.sm,
+    borderTopWidth: 1,
+    alignItems: 'flex-end',
+  },
+  input: {
+    flex: 1,
+    borderRadius: borders.radius.md,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    maxHeight: 120,
+    fontFamily: typography.fontFamily.regular,
+    fontSize: typography.fontSize.md,
+  },
+  sendButton: {
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+    marginLeft: spacing.sm,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  sosContainer: {
+    position: 'absolute',
+    bottom: 80,
+    right: spacing.md,
+    zIndex: 1,
+  },
+});
+
+export default BuddyChatScreen;

--- a/kesher/src/screens/PeerZoneScreen.tsx
+++ b/kesher/src/screens/PeerZoneScreen.tsx
@@ -109,8 +109,8 @@ const PeerZoneScreen = () => {
     if (accept && selectedBuddyForAlert) {
       // Navigate to chat with this buddy
       dispatch(setSelectedBuddy(selectedBuddyForAlert.id));
-      // Would navigate to a buddy-specific chat in a real app
-      navigation.navigate('Chat' as never);
+      // Navigate to dedicated buddy chat screen
+      navigation.navigate('BuddyChat' as never);
     }
   };
 


### PR DESCRIPTION
## Summary
- add new `BuddyChatScreen`
- register BuddyChat stack route
- open BuddyChat after accepting to talk in `PeerZoneScreen`

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm test` *(fails: jest not found)*